### PR TITLE
Improved __call__() method adding private attribute. Closes #13

### DIFF
--- a/advanced-2/advanced_2.py
+++ b/advanced-2/advanced_2.py
@@ -72,6 +72,7 @@ class VoltageData:
         tension and time must be of the same size.
         """
         self._data = np.array([tension, time], dtype=float).transpose()
+        self._spline = IUS(self.time, self.voltage, ext="raise")
 
     @classmethod
     def load_data(cls, fname):
@@ -165,11 +166,7 @@ class VoltageData:
         """
 
         #Interpolation esteem fails out self.time bonds.
-        if self.time[0]<= time_0 <= self.time[-1]:
-            spline = IUS(self.time, self.voltage, ext='zeros')
-            return spline(time_0)
-        else:
-            raise ValueError('Input data out of time measurements limits.')
+        return self._spline(time_0)
 
 #Spunto per gli unittest
 tempo = np.array([0., 1., 2., 3., 4., 6.])


### PR DESCRIPTION
Ho preferito creare questo attributo privato in modo da creare la spline una sola volta e non a ogni chiamata di __call__(). 